### PR TITLE
Feature: Warn when receiving compressed response

### DIFF
--- a/router.php
+++ b/router.php
@@ -61,6 +61,7 @@ $router_extension_mimetypes = array(
 );
 // URL Reserved Characters (RFC1738)
 $router_url_reserved_characters = array(';', '/', '?', ':', '@', '=', '&');
+$router_compressed_content_encodings = array('gzip', 'compress', 'deflate', 'br');
 
 ignore_user_abort(true);
 set_time_limit(0);
@@ -260,6 +261,7 @@ function router_write_file($file_pointer_resource, $pathname, $wrote_file) {
 // send the specified file headers
 function router_send_file_headers($file_headers) {
 	//router_output(ROUTER_TAB . 'Sending File Headers');
+	global $router_compressed_content_encodings;
 	
 	if (headers_sent() === true) {
 		return;
@@ -297,6 +299,10 @@ function router_send_file_headers($file_headers) {
 			
 			if ($file_header_lower_match === 1) {
 				// this is a valid HTTP header
+				// Warn if we received a compressed response - we can't decompress it
+				if ($file_header_lower_matches[1] === 'content-encoding' && in_array($file_header_lower_matches[2], $router_compressed_content_encodings)) {
+					router_output(ROUTER_TAB . 'Warning: Received compressed response from server. Downloaded file will be unusable.');
+				}
 				// disallow closed connections because this causes a Redirector bug
 				// also disallow the application/octet-stream mimetype
 				// and Flash dislikes Content-Disposition


### PR DESCRIPTION
Some game sites serve files compressed to save bandwidth. Flashpoint Router does not save those files correctly, so I added a feature to warn users about it.
Example game: https://www.miniclip.com/games/turbo-racing-3/game-files/webgl_jan2016/game.html